### PR TITLE
Some fixes; see especially COMNUL fix.

### DIFF
--- a/SixTrack/sixtrack.s
+++ b/SixTrack/sixtrack.s
@@ -1163,7 +1163,7 @@
 
 *     parameters for the parser
       integer getfields_n_max_fields, getfields_l_max_string
-      parameter ( getfields_n_max_fields = 20  ) ! max number of returned fields
+      parameter ( getfields_n_max_fields = 10  ) ! max number of returned fields
       parameter ( getfields_l_max_string = 161 ) ! max len of parsed line and its fields
                                                  ! (nchars in daten +1 to always make room for \0)
 
@@ -18420,14 +18420,20 @@ cc2008
       if(ierro.gt.0) call prror(-1)
       lineno3 = lineno3+1 ! Line number used for some crash output
 
-      if(ch(1:1).eq.'/') goto 2300 ! skip comment line
+      if(ch(1:1).eq.'/') goto 2300 ! skip comment lines
 
       if (ch(:4).eq.next) then
-         goto 110 ! loop BLOCK
+         goto 110 ! loop to next BLOCK in fort.3
       endif
  
       if(fma_numfiles.ge.fma_max) then
-        write(*,*) 'ERROR: you can only do ',fma_max,' number of FMAs'
++if cr
+        write(lout,*)
++ei
++if .not.cr
+        write(*,*)
++ei
+     &       'ERROR: you can only do ',fma_max,' number of FMAs'
         call prror(-1) 
       endif
 
@@ -18436,13 +18442,24 @@ cc2008
       call getfields_split( ch, getfields_fields, getfields_lfields,
      &        getfields_nfields, getfields_lerr )
       if ( getfields_lerr ) then
-        write(*,*) 'ERROR in FMA block: getfields_lerr='
-     & , getfields_lerr
++if cr
+        write(lout,*)
++ei
++if .not.cr
+        write(*,*)
++ei
+     &   'ERROR in FMA block: getfields_lerr=', getfields_lerr
         call prror(-1)
       endif
       if(getfields_nfields.ne.2) then
-        write(*,*) 'ERROR in FMA block: wrong number of input '         &
-     &    ,'parameters: ninput = ', getfields_nfields, ' != 2'
++if cr
+        write(lout,*)
++ei
++if .not.cr
+        write(*,*)
++ei
+     &        'ERROR in FMA block: wrong number of input '         &
+     &        ,'parameters: ninput = ', getfields_nfields, ' != 2'
         call prror(-1)
       endif
 
@@ -39708,7 +39725,7 @@ C     Convert r(1), r(2) from U(0,1) -> rvec0 as Gaussian with cutoff mcut (#sig
 !     always in main code
       ldumphighprec = .false.
       ldumpfront    = .false.
-      do i1=1,mper*mbloz
+      do i1=1,nblz
         do i2=1,6
           dump_clo(i1,i2)=0
           do i3=1,6

--- a/SixTrack/sixtrack.s
+++ b/SixTrack/sixtrack.s
@@ -58512,6 +58512,11 @@ c$$$            endif
 !    now we can start reading in the file
 !    - skip header
               do
+                 !KNS: Put an infinite-loop killer in this loop;
+                 ! i.e. increment some counter for each iteration,
+                 ! if it exceeds some ridiculous number (say 1000 comment lines),
+                 ! print an appropriately sarcastic error asking the user to contacting the devs,
+                 ! and exit the program.
                 read(dumpunit(j),'(A)',iostat=ierro) ch
                 call fma_error(ierro,'while reading file ' //           &
      &dump_fname(j),'fma_postpr')
@@ -58522,6 +58527,7 @@ c$$$            endif
 !   read in particle amplitudes
               fma_nturn(i) = dumplast(j)-dumpfirst(j)+1 !number of turns used for FFT
               if(fma_nturn(i).gt.fma_nturn_max) then
+                 !KNS: Very good to check it here as well, but why not check it sometime during initialization?
 +if .not.cr
                 write(*,*) 'ERROR in fma_postpr: only ',                &
      &fma_nturn_max,' turns allowed for fma and ',fma_nturn(i),' used!'

--- a/SixTrack/sixtrack.s
+++ b/SixTrack/sixtrack.s
@@ -18448,7 +18448,7 @@ cc2008
 +if .not.cr
         write(*,*)
 +ei
-     &   'ERROR in FMA block: getfields_lerr=', getfields_lerr
+     &       'ERROR in FMA block: getfields_lerr=', getfields_lerr
         call prror(-1)
       endif
       if(getfields_nfields.ne.2) then
@@ -18458,8 +18458,8 @@ cc2008
 +if .not.cr
         write(*,*)
 +ei
-     &        'ERROR in FMA block: wrong number of input '         &
-     &        ,'parameters: ninput = ', getfields_nfields, ' != 2'
+     &       'ERROR in FMA block: wrong number of input ',
+     &       'parameters: ninput = ', getfields_nfields, ' != 2'
         call prror(-1)
       endif
 
@@ -26909,7 +26909,12 @@ C     Convert r(1), r(2) from U(0,1) -> rvec0 as Gaussian with cutoff mcut (#sig
   520 continue
 !     start fma
       if(fma_flag) then
-        write(*,*) 'Calling FMA_POSTPR'
++if cr
+        write(lout,*)'Calling FMA_POSTPR'
++ei
++if .not. cr
+        write(*,*)   'Calling FMA_POSTPR'
++ei
         call fma_postpr
       endif
 !--HPLOTTING END
@@ -39749,7 +39754,7 @@ C     Convert r(1), r(2) from U(0,1) -> rvec0 as Gaussian with cutoff mcut (#sig
       enddo
       fma_flag = .false.
       fma_numfiles = 0
-      do i=0,fma_max
+      do i=1,fma_max
         fma_nturn(i) = 0
         do j=1,getfields_l_max_string
           fma_fname(i)(j:j) = char(0)
@@ -57110,7 +57115,7 @@ c$$$            endif
 !hr06     xyzv(4)=xyzv(4)*(one+xyzv(6)+clop(3))
           xyzv(4)=xyzv(4)*((one+xyzv(6))+clop(3))                        !hr06
         endif
-!MF normalisation with t-matrix 56900
+!MF normalisation with t-matrix 56900 <-- KNS What does this number refer to??
         do 320 iq=1,6
           txyz(iq)=zero
           do 320 jq=1,6
@@ -58427,7 +58432,6 @@ c$$$            endif
       logical :: lopen              !flag to check if file is already open
       logical :: lexist             !flag to check if file fma_fname exists
       logical :: lread              !flag for file reading
-      character(len=maxstrlen) :: stringzerotrim
       character(len=getfields_l_max_string) :: ch,ch1
       integer, dimension(fma_npart_max,fma_nturn_max) :: turn 
       double precision, dimension(6,6) :: fma_tas_inv ! normalisation matrix = inverse of tas -> x_normalized=fma_tas_inv*x
@@ -58537,7 +58541,7 @@ c$$$            endif
 
 !    MF: dump amplitudes in dummy files for debugging (200101)
               open(200101+i*10,status='replace',iostat=ierro,           &
-     &action='write')!MF remove, nx,nx',ny,ny'
+     &action='write')!MF remove, nx,nx',ny,ny' <- KNS: GFORTRAN warning: Replacing file without specified name (from FILE specifier in open). Not fixing since this code will be deleted before merging into master.
 !    - write closed orbit in header of file with normalized phase space coordinates (200101+i*10)
 !      units: x,xp,y,yp,sig,dp/p = [mm,mrad,mm,mrad,1]
               write(200101+i*10,1987) adjustl('# closorb'),dump_clo(j,1)&


### PR DESCRIPTION
I'm still looking over this; creating this pull request to discuss changes etc.

Question: In the "umlalid" block, write statement with format 10100, it used to scale cp(3) by 10^3. Why was this removed (i.e. is it intentional that it should stay this way)?

PS:
A Very Useful Command:
`git difftool --tool=meld master`
This gives you (in meld, which is a very very nice graphical diffing tool) the difference between the current head and the master branch (in my local clone of the repository, which should be synchronized to my fork on GitHub, and the master branch should be synched to the upstream master).
